### PR TITLE
connector_algolia: Drop index_prefix_name duplicate column

### DIFF
--- a/connector_algolia/models/se_backend_algolia.py
+++ b/connector_algolia/models/se_backend_algolia.py
@@ -38,6 +38,7 @@ class SeBackendAlgolia(models.Model):
     @property
     def _server_env_fields(self):
         env_fields = super()._server_env_fields
+        env_fields.pop("index_prefix_name")
         env_fields.update({"algolia_app_id": {}, "algolia_api_key": {}})
         return env_fields
 


### PR DESCRIPTION
this would cause server_env to lookup for `x_index_prefix_name_env_default`
on the wrong table

ping @simahawk