### PR TITLE
connector_*: fix index_prefix_name from env

### DIFF
--- a/connector_algolia/models/se_backend_algolia.py
+++ b/connector_algolia/models/se_backend_algolia.py
@@ -18,7 +18,6 @@ class SeBackendAlgolia(models.Model):
     _inherit = [
         "se.backend.spec.abstract",
         "server.env.techname.mixin",
-        "server.env.mixin",
     ]
     _description = "Algolia Backend"
 

--- a/connector_algolia/models/se_backend_algolia.py
+++ b/connector_algolia/models/se_backend_algolia.py
@@ -34,6 +34,13 @@ class SeBackendAlgolia(models.Model):
     tech_name = fields.Char(
         related="se_backend_id.tech_name", store=True, readonly=False
     )
+    # must be defined here because
+    # `se.backend.algolia` inherits (w/ the final S) from `se.backend.spec.abstract`
+    # but as of odoo 18.0  this cannot work w/ server.env.mixin
+    # as it produces a hell of field nameing and inheritance.
+    # Probably this should be fixed in server env module
+    # but this case is particular to this old implementation of SE backend.
+    index_prefix_name = fields.Char()
 
     @property
     def _server_env_fields(self):

--- a/connector_search_engine/models/se_backend_spec_abstract.py
+++ b/connector_search_engine/models/se_backend_spec_abstract.py
@@ -29,12 +29,11 @@ class SeBackendSpecAbstract(models.AbstractModel):
         delegate=True,
         required=True,
     )
-    # This must be re-defined here because
-    # we want to be able to set the prefix based on the specific search engine.
-    index_prefix_name = fields.Char(
-        related="se_backend_id.index_prefix_name",
-        readonly=False,
-    )
+    # This must be defined in the specific backend
+    # because it is used to create the index name.
+    # It is not defined in the abstract model because
+    # it leads to a valley of pain of inherited fields w/ server.env.mixin.
+    # index_prefix_name = fields.Char()
 
     @property
     def _server_env_fields(self):


### PR DESCRIPTION
Deal properly with index_prefix_name.
This field was coming from the abstract model which in turns intherited by delegation from the se.backend model, leading to a bad behavior with server.env.mixix causing the field to not be populated via env setting.

Replaces #3 