### PR TITLE
connector*: fix index name and prefix name stability

### DIFF
--- a/connector_algolia/models/se_backend_algolia.py
+++ b/connector_algolia/models/se_backend_algolia.py
@@ -33,13 +33,6 @@ class SeBackendAlgolia(models.Model):
     tech_name = fields.Char(
         related="se_backend_id.tech_name", store=True, readonly=False
     )
-    # must be defined here because
-    # `se.backend.algolia` inherits (w/ the final S) from `se.backend.spec.abstract`
-    # but as of odoo 18.0  this cannot work w/ server.env.mixin
-    # as it produces a hell of field nameing and inheritance.
-    # Probably this should be fixed in server env module
-    # but this case is particular to this old implementation of SE backend.
-    index_prefix_name = fields.Char()
 
     @property
     def _server_env_fields(self):

--- a/connector_search_engine/models/se_backend.py
+++ b/connector_search_engine/models/se_backend.py
@@ -10,7 +10,6 @@ class SeBackend(models.Model):
     _inherit = [
         "connector.backend",
         "server.env.techname.mixin",
-        "server.env.mixin",
     ]
 
     name = fields.Char(required=True)

--- a/connector_search_engine/models/se_backend_spec_abstract.py
+++ b/connector_search_engine/models/se_backend_spec_abstract.py
@@ -29,17 +29,6 @@ class SeBackendSpecAbstract(models.AbstractModel):
         delegate=True,
         required=True,
     )
-    # This must be defined in the specific backend
-    # because it is used to create the index name.
-    # It is not defined in the abstract model because
-    # it leads to a valley of pain of inherited fields w/ server.env.mixin.
-    # index_prefix_name = fields.Char()
-
-    @property
-    def _server_env_fields(self):
-        # We need this because calling `super` in the specific backend
-        # won't call the property from `se.backend` because of `inherits` behavior.
-        return {"index_prefix_name": {}}
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -11,8 +11,15 @@ _logger = logging.getLogger(__name__)
 class SeIndex(models.Model):
     _name = "se.index"
     _description = "Se Index"
+    _rec_names_search = [
+        "backend_id",
+        "backend_id.index_prefix_name",
+        "lang_id",
+        "model_id",
+        "custom_tech_name",
+    ]
 
-    name = fields.Char(compute="_compute_name", store=True)
+    name = fields.Char(compute="_compute_name")
     custom_tech_name = fields.Char(
         help="Take control of index technical name. "
         "The final index name is still computed and contains in any case: "


### PR DESCRIPTION
Having index_prefix_name coming from env is a must. Originally we were relying on the fact that server_env would update the value at each restart based on the env value.

This is not working anymore in v18 and we tried already to fix this.

One of the other goals (still possible up to v14) was to have one single config entry only for the specific backend implementation, not to have to deal with 2 different configurations.

This as well was not working properly in particular because the index name was stored hence a forced recompute was needed but also was causing caching issues on views.

In the end the solution is to keep it simple:

* index name is not stored anymore
* se.backend and se.backend.*specific* will need 2 different configurations


TODO: drop se_index.name column

**IMPORTANT: this requires that any env conf like `se_backend_algolia.xyz` is replaced w/ `se_backend.xyz`.**